### PR TITLE
US26 admin merchant update

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -6,4 +6,15 @@ class Admin::MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
+
+  def edit
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def update
+    @merchant = Merchant.find(params[:id])
+    @merchant.update!(    name: params[:name])
+    redirect_to(admin_merchant_path(@merchant.id))
+    flash[:notice] = "#{@merchant.name} has been successfully updated"
+  end
 end

--- a/app/views/admin/merchants/_form.html.erb
+++ b/app/views/admin/merchants/_form.html.erb
@@ -1,0 +1,7 @@
+
+<%= form_with url: path, method: method do |f| %>
+  <%= f.label :name, "name" %>
+  <%= f.text_field :name, value: value %>
+
+  <%= f.submit "Submit" %>
+<% end %>

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,6 @@
+<h1><%=@merchant.name%> Edit Page</h1>
+<div id="testing">
+
+
+<p><%= render partial: 'form', locals: { path: "/admin/merchants/#{@merchant.id}", method: :patch, value: @merchant.name } %></p>
+</div>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,3 +1,5 @@
 <h1><%=@merchant.name%> Show page</h1>
 
-<li>Name:<%=@merchant.name%> </li>
+  <li>Name:<%=@merchant.name%> </li>
+  <li><%= link_to "Update Merchants Info",edit_admin_merchant_path(@merchant.id) %></li>
+  <li><%= link_to "Back to All Merchants ",admin_merchants_path %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,11 @@
   </head>
 
   <body>
+    <% flash.each do |type, msg| %>
+    <div id="flash-messages">
+      <%= msg %>
+    </div>
+  <% end %>
     <%= yield %>
   </body>
 </html>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 
+
 RSpec.describe("admin merchants index page") do
   before(:each) do
     @merchant1 = Merchant.create!(    name: "Tokyos Tractors")
@@ -24,11 +25,22 @@ RSpec.describe("admin merchants index page") do
       expect(page).to(have_content("Name:#{@merchant1.name}"))
     end
 
-    it("And I see the name of that merchant") do
+    it("25.And I see the name of that merchant") do
       visit(admin_merchants_path)
       click_link("#{@merchant1.name}")
       expect(current_path).to(eq(admin_merchant_path(@merchant1.id)))
       expect(page).to(have_content("Name:#{@merchant1.name}"))
     end
+  end
+
+  describe("27.I visit the admin merchants index") do
+    describe("27.Then next to each merchant name I see a button to disable or enable that merchant.") do
+      it("I click this button") do
+        visit(admin_merchants_path)
+      end
+    end
+  end
+
+  it("27.I am redirected back to the admin merchants index & I see that the merchant's status has changed") do
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+
+RSpec.describe("admin merchants SHOW page") do
+  before(:each) do
+    @merchant1 = Merchant.create!(    name: "Tokyos Tractors")
+    @merchant2 = Merchant.create!(    name: "Oslos Outdoor Market")
+    @merchant3 = Merchant.create!(    name: "Berlins Building Supply")
+  end
+
+  describe("26.When I visit a merchant's admin show page") do
+    describe("Then I see a link to update the merchant's information.") do
+      it("26.When I click the link,I am taken to a page to edit this merchant") do
+        visit(admin_merchant_path(@merchant1.id))
+        expect(page).to(have_link("Update Merchants Info"))
+        click_link("Update Merchants Info")
+        expect(current_path).to(eq(edit_admin_merchant_path(@merchant1.id)))
+      end
+    end
+  end
+
+  describe("I see a form filled in with the existing merchant attribute information") do
+    it("26.When I update the information in the form and I click ‘submit’") do
+      visit(admin_merchant_path(@merchant1.id))
+      expect(page).to(have_link("Update Merchants Info"))
+      click_link("Update Merchants Info")
+      expect(current_path).to(eq(edit_admin_merchant_path(@merchant1.id)))
+
+      within("#testing") do
+        expect(page).to(have_field("name",         with: "Tokyos Tractors"))
+        fill_in("name",         with: "Alexs Axles")
+        click_button("Submit")
+      end
+    end
+  end
+
+  describe("I am redirected back to the merchant's admin show page where I see the updated information") do
+    it("26.I see a flash message stating that the information has been successfully updated.") do
+      visit(admin_merchant_path(@merchant1.id))
+      expect(page).to(have_link("Update Merchants Info"))
+      click_link("Update Merchants Info")
+      expect(current_path).to(eq(edit_admin_merchant_path(@merchant1.id)))
+
+      within("#testing") do
+        expect(page).to(have_field("name",         with: "Tokyos Tractors"))
+        fill_in("name",         with: "Alexs Axles")
+        click_button("Submit")
+        expect(current_path).to(eq(admin_merchant_path(@merchant1.id)))
+      end
+    end
+  end
+end

--- a/spec/features/merchants/index_spec.rb
+++ b/spec/features/merchants/index_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+
+RSpec.describe("admin merchants index page") do
+  before(:each) do
+    @merchant1 = Merchant.create!(    name: "Tokyos Tractors")
+    @merchant2 = Merchant.create!(    name: "Oslos Outdoor Market")
+    @merchant3 = Merchant.create!(    name: "Berlins Building Supply")
+  end
+
+  describe("24.admin merchants index") do
+    it("24.displays name of each merchant in the system") do
+      visit(admin_merchants_path)
+      expect(page).to(have_content(@merchant1.name))
+      expect(page).to(have_content(@merchant2.name))
+      expect(page).to(have_content(@merchant3.name))
+    end
+  end
+
+  describe("25.I click on the name of a merchant from the admin merchants index page,") do
+    it("25.I am taken to that merchant's admin show page (/admin/merchants/merchant_id)") do
+      visit(admin_merchants_path)
+      click_link("#{@merchant1.name}")
+      expect(current_path).to(eq(admin_merchant_path(@merchant1.id)))
+      expect(page).to(have_content("Name:#{@merchant1.name}"))
+    end
+
+    it("And I see the name of that merchant") do
+      visit(admin_merchants_path)
+      click_link("#{@merchant1.name}")
+      expect(current_path).to(eq(admin_merchant_path(@merchant1.id)))
+      expect(page).to(have_content("Name:#{@merchant1.name}"))
+    end
+  end
+end


### PR DESCRIPTION
US 26
created link to update merchants info
when link is clicked. take you to form
built partial _form
add pre-existing attributes to merchant when editing
created button to finalize update.
redirected back to merchants admin show page and info is updated .
flash message appears stating "merchant name" was updated successfully