### PR TITLE
Remove capitalize method

### DIFF
--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -25,7 +25,7 @@
   <div class="row">
     <div class="column">
       <div id="invoice-stats-<%= @invoice.id %>">
-          <h4><%= "Status: #{@invoice.status.capitalize}" %></h4>
+          <h4><%= "Status: #{@invoice.status}" %></h4>
           <h4><%= "Created on: #{@invoice.created_at.strftime("%A, %d %B %Y")}" %></h4>
           <h4><%= "Customer: #{@invoice.customer_last}, #{@invoice.customer_first}" %></h4>
           <h4><%= "Total Revenue: $#{sprintf('%.2f', @invoice.total_revenue)}" %></h4>
@@ -48,7 +48,7 @@
                 <th><%= item.name %></th>
                 <th><%= item.invoice_item_quantity(@invoice.id) %></th>
                 <th><%= "$" + sprintf('%.2f', item.unit_price) %></th>
-                <th><%= item.invoice_item_status(@invoice.id).capitalize %></th>
+                <th><%= item.invoice_item_status(@invoice.id) %></th>
               </tr>
             <% end %>
           </table>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'On the Merchant Invoices Show Page' do
 
         expect(page).to have_content("Invoice # #{@customer_1_invoice_1.id}")
         within "#invoice-stats-#{@customer_1_invoice_1.id}" do
-          expect(page).to have_content(@customer_1_invoice_1.status.capitalize)
+          expect(page).to have_content(@customer_1_invoice_1.status)
           expect(page).to have_content(@customer_1_invoice_1.created_at.strftime("%A, %d %B %Y"))
         end
         within "#customer-info-#{@customer_1_invoice_1.id}" do
@@ -47,12 +47,12 @@ RSpec.describe 'On the Merchant Invoices Show Page' do
           expect(page).to have_content(@merchant_1_item_1.name)
           expect(page).to have_content(@invoice_item_1.quantity)
           expect(page).to have_content(@merchant_1_item_1.unit_price)
-          expect(page).to have_content(@invoice_item_1.status.capitalize)
+          expect(page).to have_content(@invoice_item_1.status)
 
           expect(page).to have_content(@merchant_1_item_2.name)
           expect(page).to have_content(@invoice_item_2.quantity)
           expect(page).to have_content(@merchant_1_item_2.unit_price)
-          expect(page).to have_content(@invoice_item_2.status.capitalize)
+          expect(page).to have_content(@invoice_item_2.status)
         end
       end
 
@@ -61,7 +61,7 @@ RSpec.describe 'On the Merchant Invoices Show Page' do
           expect(page).to_not have_content(@merchant_2_item_1.name)
           expect(page).to_not have_content(@invoice_item_3.quantity)
           expect(page).to_not have_content(@merchant_2_item_1.unit_price)
-          expect(page).to_not have_content(@invoice_item_3.status.capitalize)
+          expect(page).to_not have_content(@invoice_item_3.status)
         end
       end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Invoice, type: :model do
-  before(:each) do 
+  before(:each) do
     @merchant1 = Merchant.create!(name: "Trey")
     @merchant2 = Merchant.create!(name: "Meredith")
 
@@ -26,7 +26,7 @@ RSpec.describe Invoice, type: :model do
     @customer_5_invoice_1 = @customer5.invoices.create!(status: 1)
 
     @customer_6_invoice_1 = @customer6.invoices.create!(status: 1)
-    @customer_6_invoice_2 = @customer6.invoices.create!(status: 0) 
+    @customer_6_invoice_2 = @customer6.invoices.create!(status: 2)
   end
 
   describe "Relationships" do
@@ -36,9 +36,9 @@ RSpec.describe Invoice, type: :model do
     it { should have_many(:items).through(:invoice_items) }
   end
 
-  describe 'class methods' do 
-    describe '#incomplete_invoices' do 
-      it 'returns the invoices that are still in progress' do 
+  describe 'class methods' do
+    describe '#incomplete_invoices' do
+      it 'returns the invoices that are still in progress' do
         expect(Invoice.incomplete_invoices).to eq([@customer_6_invoice_2])
       end
     end


### PR DESCRIPTION
This PR will:
- Remove ruby capitalize method to account for enum change.
- Model testing at 96.8% (invoice, item, customer, merchant)
- Features testing at 100%