### PR TITLE
Add commit numbers for API request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.4'
+gem 'httparty'
+
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.6'
@@ -45,7 +47,6 @@ group :development, :test do
   gem 'launchy'
   gem 'shoulda-matchers'
   gem 'orderly'
-  gem 'httparty'
 end
 
 group :development do
@@ -56,7 +57,6 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'pry-rails'
-  gem 'httparty'
 end
 
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,9 @@ class ApplicationController < ActionController::Base
     @repo_name = GithubSearch.new.repo_information
     @contributors = GithubSearch.new.contributor_names
     @latest_pr = GithubSearch.new.num_pulls
+
+    # @repo_name = Repo.new("little-esty-shop")
+    # @contributors = [Contributor.new({total: 13, author: {login: "ashuhleyt"}})]
+    # @latest_pr = Pull.new({number: 37})
   end
 end

--- a/app/poros/contributor.rb
+++ b/app/poros/contributor.rb
@@ -1,7 +1,8 @@
 class Contributor 
-  attr_reader :name
+  attr_reader :name, :num_commits
 
   def initialize(data)
-    @name = data[:login]
+    @name = data[:author][:login]
+    @num_commits = data[:total]
   end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -6,7 +6,7 @@ class GithubService
   end
 
   def contributors
-    get_url("https://api.github.com/repos/josephhilby/little-esty-shop/contributors")
+    get_url("https://api.github.com/repos/josephhilby/little-esty-shop/stats/contributors")
   end
 
   def pull_requests

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,13 @@
     <div id="flash-messages">
       <%= msg %>
     </div>
-  <% end %>
+    <% end %>
     <%= yield %>
+    <h3>Repo Name: <%= @repo_name.name %></h3>
+    <h3>Number of Pull Requests: <%=@latest_pr.number%></h3>
+    <h3>Contributors With Number of Commits:</h3>
+    <% @contributors.each do |contributor| %>
+      <p><%= "#{contributor.name}: #{contributor.num_commits}" %></p>
+    <% end %>
   </body>
 </html>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -41,8 +41,8 @@
 <div class="subtitle">
   <h2><%= subtitle %></h2>
   <ul>
-    <li><a href=<%= merchant_dashboard_index_path(@merchant) %>>Dashboard</a></li>
-    <li><a href=<%= merchant_items_path(@merchant) %>>My Items</a></li>
-    <li><a href=<%= merchant_invoices_path(@merchant) %>>My Invoices</a></li>
+    <li><%= link_to "Dashboard", merchant_dashboard_index_path(@merchant) %></li>
+    <li><%= link_to "My Items", merchant_items_path(@merchant) %></li>
+    <li><%= link_to "My Invoices", merchant_invoices_path(@merchant) %></li>
   </ul>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,7 +1,4 @@
 <h1>HELLO WORLD</h1>
-<p><%= @repo_name.name %></p>
-<% @contributors.each do |contributor| %>
-  <p><%= contributor.name %></p>
-<% end %>
+<%= link_to "Merchant #1's Dashboard", merchant_dashboard_index_path(1) %>
+<%= link_to "Admin Dashboard", "/admin" %>
 
-<p>Number of Pull Request:<%=@latest_pr.number%></p>

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -11,18 +11,17 @@ RSpec.describe("Welcome Index Page") do
       it("the project repo name") do
         expect(page).to(have_content("little-esty-shop"))
       end
-    end
-  end
 
-  describe("displays contributors names") do
-    it("will list contributor names") do
-      expect(page).to(have_content("ashuhleyt"))
-    end
-  end
+      it("the contributor names and number of commits") do
+        expect(page).to(have_content("ashuhleyt: 13"))
+        # expect(page).to(have_content("josephhilby: 54"))
+        # expect(page).to(have_content("amikaross: 47"))
+        # expect(page).to(have_content("AlexMR-93: 21"))
+      end
 
-  describe("displays latest number of PRs") do
-    it("will displays latest number of PRs") do
-      expect(page).to(have_content(35))
+      it("the latest total number of PRs") do
+        expect(page).to(have_content("Number of Pull Requests: 37"))
+      end
     end
   end
 end


### PR DESCRIPTION
This PR will:
Add the number of commits for each contributor to the api info. 
Adds duplicated variables in Application_Controller for testing purposes so we don't burn through our API hits during testing.